### PR TITLE
Update index.js import for jsvectormap

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-import "jsvectormap/dist/css/jsvectormap.css";
+import "jsvectormap/dist/jsvectormap.css";
 import "flatpickr/dist/flatpickr.min.css";
 import "../css/satoshi.css";
 import "../css/style.css";


### PR DESCRIPTION
This fixes the default path for the import which should be:

jsvectormap/dist/jsvectormap.css

In the src/js/index.js file.